### PR TITLE
WIP: Add support for php8

### DIFF
--- a/.github/workflows/php8.yml
+++ b/.github/workflows/php8.yml
@@ -1,4 +1,4 @@
-name: PHP Composer (PHP 7.3 and 7,4 support)
+name: PHP Composer (PHP 8 support)
 
 on:
   push:
@@ -9,11 +9,11 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
-        php: [7.4, 7.3]
+        php: [8.0]
         laravel: [8.*]
-        dependency-version: [prefer-lowest, prefer-stable]
+        dependency-version: [--prefer-lowest, --prefer-stable]
         include:
           - laravel: 8.*
             testbench: 6.*
@@ -41,7 +41,7 @@ jobs:
     - name: Install dependencies
       run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-progress --no-update
-          composer update --${{ matrix.dependency-version }} --prefer-dist --no-progress
+          composer update ${{ matrix.dependency-version }} --prefer-dist --no-progress
 
     - name: Run Tests
       run: composer run-script test

--- a/composer.json
+++ b/composer.json
@@ -9,25 +9,25 @@
     "homepage": "https://github.com/darkghosthunter/larapass",
     "license": "MIT",
     "type": "library",
-    "authors": [
-        {
-            "name": "Italo Israel Baeza Cabrera",
-            "email": "darkghosthunter@gmail.com",
-            "role": "Developer"
-        }
-    ],
+    "authors": [{
+        "name": "Italo Israel Baeza Cabrera",
+        "email": "darkghosthunter@gmail.com",
+        "role": "Developer"
+    }],
     "require": {
-        "php": "^7.3.0",
+        "php": "^7.3.0 || ^8.0",
         "ext-json": "*",
         "illuminate/support": "^8.0",
-        "web-auth/webauthn-lib" : "^3.2",
+        "web-auth/webauthn-lib": "^3.2",
         "symfony/psr-http-message-bridge": "^2.0",
         "ramsey/uuid": "^4.0",
         "nyholm/psr7": "^1.3"
     },
+    "minimum-stability": "dev",
     "require-dev": {
         "orchestra/testbench": "^6.0",
-        "phpunit/phpunit": "^8.5||^9.0"
+        "phpunit/phpunit": "^8.5||^9.0",
+        "mockery/mockery": ">=1.4"
     },
     "autoload": {
         "psr-4": {

--- a/src/WebAuthn/AuthenticatorSelectionCriteria.php
+++ b/src/WebAuthn/AuthenticatorSelectionCriteria.php
@@ -13,7 +13,7 @@ class AuthenticatorSelectionCriteria extends WebAuthnAuthenticatorSelectionCrite
      *
      * @param  string  $type
      */
-    public function setResidentKey(string $type)
+    public function setResidentKey(?string $type) : WebAuthnAuthenticatorSelectionCriteria
     {
         if (! in_array($type, [self::USER_VERIFICATION_REQUIREMENT_REQUIRED,
             self::USER_VERIFICATION_REQUIREMENT_PREFERRED,
@@ -22,9 +22,11 @@ class AuthenticatorSelectionCriteria extends WebAuthnAuthenticatorSelectionCrite
         }
 
         $this->residentKey = $type;
+
+        return $this;
     }
 
-    public function getResidentKey()
+    public function getResidentKey() : ?string
     {
         return $this->residentKey;
     }


### PR DESCRIPTION
PHP 8 got officially released on November 26, 2020.

This patch proposes some ground work towards php 8.

It solves some dependencies as follows:
- Require mockery/mockery v1.4 for the tests.
- allow dev packages so that webauth-lib v3.3 is accepted for php 8
- Fixes some types changes with regard to the future versions of webauth-lib