### PR TITLE
Fixes config mismatches

### DIFF
--- a/src/LarapassServiceProvider.php
+++ b/src/LarapassServiceProvider.php
@@ -195,7 +195,7 @@ class LarapassServiceProvider extends ServiceProvider
                 $config = $app['config'];
 
                 $selection = new WebAuthn\AuthenticatorSelectionCriteria(
-                    $config->get('larapass.cross-plataform')
+                    $config->get('larapass.attachment')
                 );
 
                 if ($userless = $config->get('larapass.userless')) {


### PR DESCRIPTION
There was config mismatch for "attachment" which was originally named "cross-plataform". This caused "attachment"  to have no effect.